### PR TITLE
InputControl: Infer type instead of explicit typing

### DIFF
--- a/src/input-control/index.tsx
+++ b/src/input-control/index.tsx
@@ -1,27 +1,28 @@
 import { Input, InputProps } from '@chakra-ui/react';
 import { useField, useFormikContext } from 'formik';
-import React, { FC, ForwardedRef } from 'react';
+import React from 'react';
 import { BaseProps, FormControl } from '../form-control';
 
 export type InputControlProps = BaseProps & { inputProps?: InputProps };
 
-export const InputControl: FC<InputControlProps> = React.forwardRef(
-  (props: InputControlProps, ref: ForwardedRef<HTMLInputElement>) => {
-    const { name, label, inputProps, ...rest } = props;
-    const [field] = useField(name);
-    const { isSubmitting } = useFormikContext();
-    return (
-      <FormControl name={name} label={label} {...rest}>
-        <Input
-          {...field}
-          id={name}
-          isDisabled={isSubmitting}
-          {...inputProps}
-          ref={ref}
-        />
-      </FormControl>
-    );
-  }
-);
+export const InputControl = React.forwardRef<
+  HTMLInputElement,
+  InputControlProps
+>((props, ref) => {
+  const { name, label, inputProps, ...rest } = props;
+  const [field] = useField(name);
+  const { isSubmitting } = useFormikContext();
+  return (
+    <FormControl name={name} label={label} {...rest}>
+      <Input
+        {...field}
+        id={name}
+        isDisabled={isSubmitting}
+        {...inputProps}
+        ref={ref}
+      />
+    </FormControl>
+  );
+});
 
 export default InputControl;


### PR DESCRIPTION
Seems like it does not work. Importing `InputControl` causes any type.